### PR TITLE
feat(ax): add ax_select tool for NSOutlineView / NSTableView row selection

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,7 +17,7 @@ For robust automation, follow this "Visual Feedback Loop":
 3.  **ACT:** Call `click()`, `type_text()`, or `scroll()` using those coordinates.
 4.  **VERIFY:** Call `take_screenshot` again to confirm the action had the intended effect.
 
-**macOS-preferred branch (native apps):** substitute OBSERVE with `take_ax_snapshot(app_name='...')`; LOCATE reads uid + bbox from the emitted tree; ACT calls `ax_click(uid)` or `ax_set_value(uid, text)`; VERIFY re-snapshots and reads the new state. This branch does not move the cursor or steal focus, so it composes with background work.
+**macOS-preferred branch (native apps):** substitute OBSERVE with `take_ax_snapshot(app_name='...')`; LOCATE reads uid + bbox from the emitted tree; ACT calls `ax_click(uid)` for pressable controls, `ax_set_value(uid, text)` for text fields, or `ax_select(uid)` for `NSOutlineView` / `NSTableView` row selection (sidebars, rule lists); VERIFY re-snapshots and reads the new state. This branch does not move the cursor or steal focus, so it composes with background work.
 
 ---
 
@@ -39,6 +39,7 @@ Use this table to choose the right tool sequence for the user's goal.
 | "Quit an app" | `quit_app(app_name="Safari")` | Graceful by default; use `force=true` to kill immediately. |
 | "Click a named button in a native app (macOS)" | `take_ax_snapshot` → `ax_click(uid)` | Focus-preserving. Generation-tagged uids; fresh snapshot invalidates prior uids. |
 | "Enter text into a text field via value assignment (macOS)" | `take_ax_snapshot` → `ax_set_value(uid, text)` | No key events, no IME, no undo-stack entry. Fall back to `click` + `type_text` on `not_dispatchable`. |
+| "Select a sidebar row in System Settings / a `NSOutlineView` row (macOS)" | `take_ax_snapshot` → `ax_select(uid)` | Writes `AXSelectedRows` on the enclosing outline/table. Use this instead of `ax_click` for row targets — rows typically refuse `AXPress`. |
 | "AX snapshot invalidation rule (macOS)" | — | Every `take_ax_snapshot` call bumps the generation. All prior uids become stale; `ax_*` tools return `snapshot_expired`. |
 | "Click a button in Chrome" | `cdp_connect(port=9222)` → `cdp_take_ax_snapshot()` → `cdp_click(uid="a42")` | CDP is more reliable than coordinates for web content. |
 | "Type in a web input" | `cdp_take_ax_snapshot()` → `cdp_fill(uid="a42", value="hello")` | Works for `<input>`, `<textarea>`, and `<select>` elements. |
@@ -62,9 +63,9 @@ Use this table to choose the right tool sequence for the user's goal.
 **Schema:**
 - `app_name: string` (optional) — target app; defaults to frontmost.
 
-**macOS session state:** on macOS this tool is no longer a pure read — it writes session state. Every call bumps a monotonic generation and replaces the server's cached map of `AXUIElement` handles. Uids are emitted as `a<N>g<gen>` (e.g. `a42g3`). All uids from prior snapshots become stale for `ax_click` / `ax_set_value` consumption (return `snapshot_expired`). Windows behavior is unchanged — no session, uids stay bare `a<N>`.
+**macOS session state:** on macOS this tool is no longer a pure read — it writes session state. Every call bumps a monotonic generation and replaces the server's cached map of `AXUIElement` handles. Uids are emitted as `a<N>g<gen>` (e.g. `a42g3`). All uids from prior snapshots become stale for `ax_click` / `ax_set_value` / `ax_select` consumption (return `snapshot_expired`). Windows behavior is unchanged — no session, uids stay bare `a<N>`.
 
-**Usage pattern (macOS):** snapshot immediately before each `ax_click` / `ax_set_value` call to avoid `snapshot_expired`. Every branch or retry starts with a fresh snapshot.
+**Usage pattern (macOS):** snapshot immediately before each `ax_click` / `ax_set_value` / `ax_select` call to avoid `snapshot_expired`. Every branch or retry starts with a fresh snapshot.
 
 #### `take_screenshot`
 Captures pixel data and layout.
@@ -170,6 +171,23 @@ Types text at the *current* cursor position.
 - Only works on elements that expose a writable `kAXValueAttribute` (e.g. `AXTextField`, `AXTextArea`, `AXSearchField`).
 
 **Fallback on `not_dispatchable`:** perform `click(fallback.x, fallback.y)` to focus, then `type_text(text)` for true key-event input.
+
+#### `ax_select` (macOS only)
+
+**Purpose:** Select a row inside an `NSOutlineView` / `NSTableView` by writing `AXSelectedRows` on the enclosing outline/table. Use for sidebars (System Settings, Mail, Xcode, Finder), rule lists, and any native browser-style row container where `AXPress` is not supported.
+
+**Schema:**
+- `uid: string` — generation-tagged uid. Points at the row itself, a cell inside the row, or any descendant; the tool walks up to the enclosing `AXRow`.
+
+**Response:**
+- Success: `{ "ok": true, "dispatched_via": "AXSelectedRows", "bbox": { "x", "y", "w", "h" } }`. The bbox describes the resolved row (not necessarily the uid-targeted descendant).
+- Error: same envelope as `ax_click` with codes `snapshot_expired`, `uid_not_found`, `no_row_ancestor`, `no_outline_container`, `not_dispatchable`, `ax_error`.
+
+**When to reach for `ax_select` vs `ax_click`:** rows in native sidebars typically refuse `AXPress` — `ax_click` returns `not_dispatchable` or AX error `-25205` against them. Use `ax_select` for row targets. A coordinate-based fallback (`click(x, y)`) works but steals focus — the whole reason `ax_*` exists.
+
+**Gotchas:**
+- `no_row_ancestor` means the uid is not inside a row at all — you probably targeted the wrong element. Re-snapshot and pick the `AXRow` or one of its descendants.
+- `no_outline_container` means the row exists but is not nested in an `AXOutline` / `AXTable` — unusual; custom row containers may need `click(fallback.x, fallback.y)`.
 
 #### `scroll`
 Scrolls at a specific screen position.

--- a/README.md
+++ b/README.md
@@ -94,8 +94,6 @@ ax_select(uid='a18g3')                         # select a sidebar / table row vi
 | `ax_set_value` | write `kAXValueAttribute` | Text fields, search fields, stepper-backed inputs |
 | `ax_select` | write `AXSelectedRows` | `NSOutlineView` / `NSTableView` row selection (sidebars, rule lists, file browsers) |
 
-Rows in sidebars typically refuse `AXPress` — `ax_click` returns `not_dispatchable` or AX error `-25205`. Use `ax_select` for those targets instead of falling back to `click(x, y)`, which would steal focus.
-
 **Invalidation rule:** every fresh `take_ax_snapshot` bumps the generation. All uids from prior snapshots become stale immediately — `ax_click` / `ax_set_value` / `ax_select` will reject them with `snapshot_expired`. Snapshot immediately before you dispatch.
 
 **When `ax_set_value` is not a substitute for typing:** `ax_set_value` writes `kAXValueAttribute` — it does not fire keydown/keyup, does not participate in IME composition, and does not populate the app's undo stack. If you need those semantics, fall back to `click(x, y)` + `type_text(text)` using the `fallback` bbox the tool returns on `not_dispatchable`.

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ npx -y native-devtools-mcp
 
 **Core capabilities**
 - Screenshots, OCR, and accessibility-first `find_text`
-- **Element-precise, focus-preserving automation (macOS):** `take_ax_snapshot` → `ax_click` / `ax_set_value` — dispatch against Accessibility-tree elements without moving the mouse or stealing focus. Generation-tagged uids (`a<N>g<gen>`) make stale snapshots fail loud instead of silently targeting the wrong element.
+- **Element-precise, focus-preserving automation (macOS):** `take_ax_snapshot` → `ax_click` / `ax_set_value` / `ax_select` — dispatch against Accessibility-tree elements without moving the mouse or stealing focus. Generation-tagged uids (`a<N>g<gen>`) make stale snapshots fail loud instead of silently targeting the wrong element.
 - `click`, `type_text`, `scroll`, `launch_app`, `quit_app`, and window management
 - `element_at_point` for inspecting accessible UI elements at screen coordinates
 - `load_image` + `find_image` for non-text UI elements such as icons and custom controls
@@ -79,13 +79,24 @@ This MCP server is designed to be **highly discoverable and usable** by AI model
 ### Element-precise AX dispatch (macOS, preferred for native apps)
 
 ```
-take_ax_snapshot(app_name='Calculator')
+take_ax_snapshot(app_name='System Settings')
   → tree with uids like `a42g3` (generation-tagged) and bboxes
-ax_click(uid='a42g3')                          # press without stealing focus
-ax_set_value(uid='a5g3', text='hello world')   # write via kAXValueAttribute
+ax_click(uid='a42g3')                          # press a button / menu item
+ax_set_value(uid='a5g3', text='hello world')   # write a text field via kAXValueAttribute
+ax_select(uid='a18g3')                         # select a sidebar / table row via AXSelectedRows
 ```
 
-**Invalidation rule:** every fresh `take_ax_snapshot` bumps the generation. All uids from prior snapshots become stale immediately — `ax_click` / `ax_set_value` will reject them with `snapshot_expired`. Snapshot immediately before you dispatch.
+**Picking the right dispatch primitive:**
+
+| Primitive | AX mechanism | Best for |
+|-----------|--------------|----------|
+| `ax_click` | `AXPress` action | Buttons, menu items, checkboxes, toolbar items |
+| `ax_set_value` | write `kAXValueAttribute` | Text fields, search fields, stepper-backed inputs |
+| `ax_select` | write `AXSelectedRows` | `NSOutlineView` / `NSTableView` row selection (sidebars, rule lists, file browsers) |
+
+Rows in sidebars typically refuse `AXPress` — `ax_click` returns `not_dispatchable` or AX error `-25205`. Use `ax_select` for those targets instead of falling back to `click(x, y)`, which would steal focus.
+
+**Invalidation rule:** every fresh `take_ax_snapshot` bumps the generation. All uids from prior snapshots become stale immediately — `ax_click` / `ax_set_value` / `ax_select` will reject them with `snapshot_expired`. Snapshot immediately before you dispatch.
 
 **When `ax_set_value` is not a substitute for typing:** `ax_set_value` writes `kAXValueAttribute` — it does not fire keydown/keyup, does not participate in IME composition, and does not populate the app's undo stack. If you need those semantics, fall back to `click(x, y)` + `type_text(text)` using the `fallback` bbox the tool returns on `not_dispatchable`.
 

--- a/src/macos/ax.rs
+++ b/src/macos/ax.rs
@@ -6,8 +6,8 @@
 
 use super::ocr::{TextBounds, TextMatch};
 use crate::tools::ax_snapshot::{map_ax_role, AXSnapshotNode};
-use core_foundation::array::CFArray;
-use core_foundation::base::{CFType, TCFType};
+use core_foundation::array::{kCFTypeArrayCallBacks, CFArray, CFArrayCreate};
+use core_foundation::base::{kCFAllocatorDefault, CFType, TCFType};
 use core_foundation::boolean::CFBoolean;
 use core_foundation::string::CFString;
 use core_graphics::geometry::{CGPoint, CGSize};
@@ -374,6 +374,114 @@ pub(crate) fn set_value_attribute(element: &AXRef, text: &str) -> Result<(), AXD
             element.as_raw(),
             attr.as_concrete_TypeRef(),
             value.as_concrete_TypeRef() as core_foundation::base::CFTypeRef,
+        )
+    };
+    match AXDispatchError::from_set_value_code(code) {
+        None => Ok(()),
+        Some(e) => Err(e),
+    }
+}
+
+/// Read the `AXRole` attribute of an element as a `String`, or `None` when
+/// the attribute is unavailable or not a string.
+///
+/// Used by `find_ancestor_with_role` during the row-resolution walk.
+/// Crate-internal so external consumers cannot recreate the
+/// lookup-then-dispatch race `AxSession::dispatch` exists to close.
+fn ax_role(element: &AXRef) -> Option<String> {
+    unsafe { get_string_attribute(element.as_raw(), "AXRole") }
+}
+
+/// Return the AX parent of `element` if the attribute is readable.
+///
+/// The returned `AXRef` is retained via `from_get`; drop semantics mirror
+/// every other `AXRef` in the crate. Private — the blessed way to walk
+/// ancestors is `ancestor_role_chain`, which is what `ax_select`
+/// consumes. Leaving `ax_parent` `pub(crate)` would let intra-crate
+/// callers walk the tree outside `AxSession::dispatch`'s read lock.
+fn ax_parent(element: &AXRef) -> Option<AXRef> {
+    let attr = CFString::new("AXParent");
+    let mut value_ref: core_foundation::base::CFTypeRef = ptr::null();
+    let err = unsafe {
+        AXUIElementCopyAttributeValue(element.as_raw(), attr.as_concrete_TypeRef(), &mut value_ref)
+    };
+    if err != K_AX_ERROR_SUCCESS || value_ref.is_null() {
+        return None;
+    }
+    // value_ref is owned (create rule). `from_get` retains, so we release the
+    // copy to keep the net refcount balanced.
+    let parent = unsafe { AXRef::from_get(value_ref as AXUIElementRef) };
+    unsafe {
+        core_foundation::base::CFRelease(value_ref);
+    }
+    Some(parent)
+}
+
+/// Number of parent links to traverse when hunting for an enclosing role.
+/// Deep-enough to absorb the intermediate cells/groups native sidebars wrap
+/// their rows in, shallow enough to bail cleanly on a pathological cycle.
+const AX_ANCESTOR_WALK_LIMIT: u32 = 32;
+
+/// Walk up the `AXParent` chain starting from `start` (inclusive) and
+/// return a leaf-to-root vector of `(AXRef, Option<role>)` pairs.
+///
+/// The walk stops when `AXParent` becomes unreadable or when
+/// `AX_ANCESTOR_WALK_LIMIT` is reached — either way a bounded vector is
+/// returned rather than an error. Downstream logic (`ax_select`) inspects
+/// the chain to pick out the enclosing `AXRow` and `AXOutline`/`AXTable`;
+/// splitting the walk from the decision lets the decision logic be unit
+/// tested without live `AXUIElement` handles.
+pub(crate) fn ancestor_role_chain(start: &AXRef) -> Vec<(AXRef, Option<String>)> {
+    let mut chain: Vec<(AXRef, Option<String>)> = Vec::new();
+    let mut current = start.clone();
+    for _ in 0..AX_ANCESTOR_WALK_LIMIT {
+        let role = ax_role(&current);
+        chain.push((current.clone(), role));
+        match ax_parent(&current) {
+            Some(p) => current = p,
+            None => break,
+        }
+    }
+    chain
+}
+
+/// Write `rows` into the `AXSelectedRows` attribute of an outline/table.
+/// Returns `Ok(())` on success.
+///
+/// Callers must have already walked up to the enclosing `AXOutline` /
+/// `AXTable` and verified the row is a direct descendant. The MVP selects
+/// exactly one row per call — the list shape leaves room for multi-row
+/// selection later without re-plumbing the FFI boundary.
+///
+/// Narrowed to `pub(crate)` so external Rust consumers cannot combine it
+/// with `AxSession::lookup` to recreate the lookup-then-dispatch race that
+/// `AxSession::dispatch` exists to close.
+pub(crate) fn select_rows_attribute(
+    container: &AXRef,
+    rows: &[&AXRef],
+) -> Result<(), AXDispatchError> {
+    let attr = CFString::new("AXSelectedRows");
+    // Build a CFArray<AXUIElementRef>. `kCFTypeArrayCallBacks` tells CFArray
+    // to CFRetain each pointer on insert and CFRelease on destruction, which
+    // is what we want for `AXUIElementRef` — a CFType under the hood. Using
+    // `CFArray::from_copyable` would pass a null callback set, producing a
+    // bag of unmanaged raw pointers that AX probably still accepts but that
+    // leaks refcount semantics across the FFI boundary.
+    let raw_ptrs: Vec<*const c_void> = rows.iter().map(|r| r.as_raw() as *const c_void).collect();
+    let cf_array_ref = unsafe {
+        CFArrayCreate(
+            kCFAllocatorDefault,
+            raw_ptrs.as_ptr(),
+            raw_ptrs.len() as core_foundation::base::CFIndex,
+            &kCFTypeArrayCallBacks,
+        )
+    };
+    let cf_array: CFArray<*const c_void> = unsafe { CFArray::wrap_under_create_rule(cf_array_ref) };
+    let code = unsafe {
+        AXUIElementSetAttributeValue(
+            container.as_raw(),
+            attr.as_concrete_TypeRef(),
+            cf_array.as_concrete_TypeRef() as core_foundation::base::CFTypeRef,
         )
     };
     match AXDispatchError::from_set_value_code(code) {

--- a/src/macos/ax.rs
+++ b/src/macos/ax.rs
@@ -108,11 +108,6 @@ impl AXRef {
     /// holds a +1 refcount and transfers ownership to the `AXRef`. Drop will
     /// balance with a single `CFRelease`. Do not call `CFRelease` on the raw
     /// pointer after calling this.
-    ///
-    /// Currently only exercised by tests and by synthetic `AXRef` construction
-    /// in the session tests; the production tree-walk uses `from_get`. Kept
-    /// as part of the symmetric create/get API contract.
-    #[allow(dead_code)]
     pub(crate) unsafe fn from_create(raw: AXUIElementRef) -> Self {
         AXRef(Arc::new(AXRefInner(raw)))
     }
@@ -382,23 +377,10 @@ pub(crate) fn set_value_attribute(element: &AXRef, text: &str) -> Result<(), AXD
     }
 }
 
-/// Read the `AXRole` attribute of an element as a `String`, or `None` when
-/// the attribute is unavailable or not a string.
-///
-/// Used by `find_ancestor_with_role` during the row-resolution walk.
-/// Crate-internal so external consumers cannot recreate the
-/// lookup-then-dispatch race `AxSession::dispatch` exists to close.
-fn ax_role(element: &AXRef) -> Option<String> {
-    unsafe { get_string_attribute(element.as_raw(), "AXRole") }
-}
-
 /// Return the AX parent of `element` if the attribute is readable.
 ///
-/// The returned `AXRef` is retained via `from_get`; drop semantics mirror
-/// every other `AXRef` in the crate. Private — the blessed way to walk
-/// ancestors is `ancestor_role_chain`, which is what `ax_select`
-/// consumes. Leaving `ax_parent` `pub(crate)` would let intra-crate
-/// callers walk the tree outside `AxSession::dispatch`'s read lock.
+/// Private — walking ancestors outside `AxSession::dispatch`'s read lock
+/// reopens the lookup-then-dispatch race `dispatch` exists to close.
 fn ax_parent(element: &AXRef) -> Option<AXRef> {
     let attr = CFString::new("AXParent");
     let mut value_ref: core_foundation::base::CFTypeRef = ptr::null();
@@ -408,13 +390,9 @@ fn ax_parent(element: &AXRef) -> Option<AXRef> {
     if err != K_AX_ERROR_SUCCESS || value_ref.is_null() {
         return None;
     }
-    // value_ref is owned (create rule). `from_get` retains, so we release the
-    // copy to keep the net refcount balanced.
-    let parent = unsafe { AXRef::from_get(value_ref as AXUIElementRef) };
-    unsafe {
-        core_foundation::base::CFRelease(value_ref);
-    }
-    Some(parent)
+    // `AXUIElementCopyAttributeValue` returns under the create rule, so
+    // `from_create` takes that +1 directly — no CFRetain/CFRelease pair.
+    Some(unsafe { AXRef::from_create(value_ref as AXUIElementRef) })
 }
 
 /// Number of parent links to traverse when hunting for an enclosing role.
@@ -435,7 +413,7 @@ pub(crate) fn ancestor_role_chain(start: &AXRef) -> Vec<(AXRef, Option<String>)>
     let mut chain: Vec<(AXRef, Option<String>)> = Vec::new();
     let mut current = start.clone();
     for _ in 0..AX_ANCESTOR_WALK_LIMIT {
-        let role = ax_role(&current);
+        let role = unsafe { get_string_attribute(current.as_raw(), "AXRole") };
         chain.push((current.clone(), role));
         match ax_parent(&current) {
             Some(p) => current = p,

--- a/src/server.rs
+++ b/src/server.rs
@@ -314,7 +314,7 @@ impl MacOSDevToolsServer {
         {
             annotate_tools(
                 tools,
-                &["ax_click", "ax_set_value"],
+                &["ax_click", "ax_set_value", "ax_select"],
                 annotate_state_change(),
             );
         }
@@ -867,9 +867,10 @@ impl MacOSDevToolsServer {
                  any app without requiring a debug port. \
                  macOS note: this tool mutates server state — each call bumps a \
                  monotonic generation and invalidates every prior uid for ax_click / \
-                 ax_set_value consumption. Snapshot IDs on macOS look like 'a42g3' \
-                 (generation-tagged); Windows IDs remain bare 'a42'. Re-snapshot \
-                 immediately before any ax_click / ax_set_value call.",
+                 ax_set_value / ax_select consumption. Snapshot IDs on macOS look like \
+                 'a42g3' (generation-tagged); Windows IDs remain bare 'a42'. \
+                 Re-snapshot immediately before any ax_click / ax_set_value / ax_select \
+                 call.",
                 Arc::new(json_to_object(serde_json::json!({
                     "type": "object",
                     "properties": {
@@ -899,6 +900,7 @@ impl MacOSDevToolsServer {
         {
             tools.push(Self::get_ax_click_tool());
             tools.push(Self::get_ax_set_value_tool());
+            tools.push(Self::get_ax_select_tool());
         }
         tools
     }
@@ -950,6 +952,36 @@ impl MacOSDevToolsServer {
                     "text": {
                         "type": "string",
                         "description": "Text to assign via kAXValueAttribute."
+                    }
+                }
+            }))),
+        )
+    }
+
+    #[cfg(target_os = "macos")]
+    fn get_ax_select_tool() -> Tool {
+        Tool::new(
+            "ax_select",
+            "macOS only. Select a row inside an NSOutlineView / NSTableView (sidebars, \
+             rule lists, file browsers) by writing AXSelectedRows on the enclosing \
+             outline or table. Accepts a uid pointing at the row, a cell inside the row, \
+             or any descendant — the tool walks up to the enclosing AXRow then the \
+             enclosing AXOutline / AXTable. Does not move the cursor and does not steal \
+             focus. Use ax_select instead of ax_click for row targets: rows typically \
+             refuse AXPress (returning not_dispatchable or AX error -25205), and a \
+             coordinate click steals focus. On failure the tool returns { error: { code, \
+             message, fallback: { x, y } | null } } with codes snapshot_expired, \
+             uid_not_found, no_row_ancestor, no_outline_container, not_dispatchable, or \
+             ax_error. The fallback centre falls back from the row bbox to the \
+             originally-targeted element bbox so the caller can still click(x, y) if \
+             desired.",
+            Arc::new(json_to_object(serde_json::json!({
+                "type": "object",
+                "required": ["uid"],
+                "properties": {
+                    "uid": {
+                        "type": "string",
+                        "description": "Element uid from the most recent take_ax_snapshot. Points at the row itself, a cell within the row, or any descendant."
                     }
                 }
             }))),
@@ -1790,7 +1822,7 @@ impl ServerHandler for MacOSDevToolsServer {
         #[cfg(target_os = "macos")]
         {
             instructions.push_str(
-                "- Desktop apps (element-precise, macOS only): ax_* (ax_click, ax_set_value) — focus-preserving dispatch against uids from take_ax_snapshot.\n",
+                "- Desktop apps (element-precise, macOS only): ax_* (ax_click, ax_set_value, ax_select) — focus-preserving dispatch against uids from take_ax_snapshot.\n",
             );
         }
 
@@ -1816,11 +1848,15 @@ impl ServerHandler for MacOSDevToolsServer {
             instructions.push_str(
                 "ELEMENT-PRECISE AUTOMATION (macOS, PREFERRED for native apps): \
                  Call take_ax_snapshot(app_name='...') to get a tree of elements tagged \
-                 with generation-stamped uids like 'a42g3'. Then use ax_click(uid='a42g3') \
-                 to press a button without stealing focus, or ax_set_value(uid='a5g3', \
-                 text='...') to write to a text field via kAXValueAttribute. IMPORTANT: \
-                 any fresh take_ax_snapshot invalidates all prior uids — snapshot \
-                 immediately before each ax_click / ax_set_value call. ax_set_value is \
+                 with generation-stamped uids like 'a42g3'. Then pick the dispatch \
+                 primitive that matches the target: ax_click(uid) dispatches AXPress for \
+                 buttons, menu items, and anything pressable; ax_set_value(uid, text) \
+                 writes kAXValueAttribute on text fields; ax_select(uid) writes \
+                 AXSelectedRows for NSOutlineView / NSTableView row selection (sidebars, \
+                 rule lists, file browsers) — rows typically refuse AXPress so ax_click \
+                 returns not_dispatchable or AX error -25205 against them. IMPORTANT: any \
+                 fresh take_ax_snapshot invalidates all prior uids — snapshot immediately \
+                 before each ax_click / ax_set_value / ax_select call. ax_set_value is \
                  value assignment, not keystrokes: no IME, no undo-stack entry. If a call \
                  fails with not_dispatchable and returns a fallback {x, y}, retry via \
                  click(x, y) (plus type_text(text) for ax_set_value).\n\n",
@@ -2084,6 +2120,12 @@ impl ServerHandler for MacOSDevToolsServer {
                     serde_json::from_value(args)
                         .map_err(|e| McpError::invalid_params(e.to_string(), None))?;
                 Ok(crate::tools::ax_set_value::ax_set_value(params, self.ax_session.clone()).await)
+            }
+            #[cfg(target_os = "macos")]
+            "ax_select" => {
+                let params: crate::tools::ax_select::AxSelectParams = serde_json::from_value(args)
+                    .map_err(|e| McpError::invalid_params(e.to_string(), None))?;
+                Ok(crate::tools::ax_select::ax_select(params, self.ax_session.clone()).await)
             }
             "probe_app" => {
                 let params: crate::tools::probe_app::ProbeAppParams = serde_json::from_value(args)

--- a/src/tools/ax_row_target.rs
+++ b/src/tools/ax_row_target.rs
@@ -1,0 +1,232 @@
+//! Pure row-resolution logic for `ax_select`.
+//!
+//! Callers hand this module a uid-targeted starting element and an
+//! ancestor-walk. The algorithm:
+//!
+//! 1. Walk up from the start element (inclusive) looking for the first
+//!    ancestor with `AXRole == "AXRow"`. That is the row we will select.
+//! 2. Walk up from the row (exclusive) looking for the first ancestor whose
+//!    `AXRole` is `"AXOutline"` or `"AXTable"`. That is the container whose
+//!    `AXSelectedRows` attribute we will write.
+//!
+//! Failure modes:
+//! - `NoRow` — the start element and every walk-limited ancestor failed to
+//!   expose an `AXRow`. `ax_select` was aimed at an element that is not
+//!   inside a row.
+//! - `NoContainer` — a row was found but none of its ancestors within the
+//!   walk limit is an outline or table. Unusual — typically means the host
+//!   app nests rows inside a non-standard container.
+//!
+//! Both failures carry the walk depth we reached so handlers can include it
+//! in their error envelope.
+//!
+//! # Why a pure function
+//!
+//! The production walk calls into `AXParent` / `AXRole` FFI which requires
+//! live `AXUIElementRef` handles. We cannot construct those in a unit test
+//! without going through the full app snapshot path. This module expresses
+//! the decision logic as `resolve_row_and_container(roles)` where `roles`
+//! is a leaf-to-root slice of role strings the integration layer has
+//! already read. That lets us unit-test every branch (cell→row, deeper
+//! descendant→row, non-row-descendant fails, row-without-outline fails)
+//! without the FFI.
+
+/// Role strings we consider candidate rows and containers.
+const ROW_ROLE: &str = "AXRow";
+const OUTLINE_ROLE: &str = "AXOutline";
+const TABLE_ROLE: &str = "AXTable";
+
+/// Outcome of the row-resolution walk over a precomputed ancestor role chain.
+///
+/// Returned indices refer into the input slice: `ancestor_roles[0]` is the
+/// starting element, `ancestor_roles[1]` its parent, and so on. `row_idx`
+/// is always strictly less than `container_idx` because the walk for the
+/// container starts one step above the row.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum RowResolution {
+    Resolved {
+        row_idx: usize,
+        container_idx: usize,
+    },
+    NoRow {
+        depth_walked: usize,
+    },
+    NoContainer {
+        row_idx: usize,
+        depth_walked: usize,
+    },
+}
+
+/// Resolve `(row, container)` over a leaf-to-root role chain.
+///
+/// `ancestor_roles[0]` is the starting element, each subsequent entry is
+/// one parent up. `None` represents an ancestor whose `AXRole` was
+/// unreadable — common near the app root, and not fatal unless we run out
+/// of ancestors before finding a row or container.
+pub(crate) fn resolve_row_and_container(ancestor_roles: &[Option<&str>]) -> RowResolution {
+    let depth_walked = ancestor_roles.len();
+
+    // Phase 1: find the row (inclusive of the starting element).
+    let Some(row_idx) = ancestor_roles
+        .iter()
+        .position(|r| matches!(r, Some(role) if *role == ROW_ROLE))
+    else {
+        return RowResolution::NoRow { depth_walked };
+    };
+
+    // Phase 2: find the outline/table container above the row (exclusive).
+    let Some(offset) = ancestor_roles[row_idx + 1..].iter().position(
+        |r| matches!(r, Some(role) if *role == OUTLINE_ROLE || *role == TABLE_ROLE),
+    ) else {
+        return RowResolution::NoContainer {
+            row_idx,
+            depth_walked,
+        };
+    };
+    let container_idx = row_idx + 1 + offset;
+
+    RowResolution::Resolved {
+        row_idx,
+        container_idx,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn some(s: &str) -> Option<&str> {
+        Some(s)
+    }
+
+    // Helper — build a role chain from string slices so tests read cleanly.
+    fn chain<'a>(roles: &[&'a str]) -> Vec<Option<&'a str>> {
+        roles.iter().map(|r| Some(*r)).collect()
+    }
+
+    #[test]
+    fn row_as_start_resolves_to_itself() {
+        // uid pointed directly at the row.
+        let roles = chain(&["AXRow", "AXOutline", "AXScrollArea", "AXWindow"]);
+        assert_eq!(
+            resolve_row_and_container(&roles),
+            RowResolution::Resolved {
+                row_idx: 0,
+                container_idx: 1,
+            }
+        );
+    }
+
+    #[test]
+    fn cell_start_resolves_to_parent_row() {
+        // uid pointed at the row's cell.
+        let roles = chain(&["AXCell", "AXRow", "AXOutline", "AXScrollArea", "AXWindow"]);
+        assert_eq!(
+            resolve_row_and_container(&roles),
+            RowResolution::Resolved {
+                row_idx: 1,
+                container_idx: 2,
+            }
+        );
+    }
+
+    #[test]
+    fn deeper_descendant_resolves_to_enclosing_row() {
+        // uid pointed at a static-text/image inside a cell inside a row.
+        let roles = chain(&[
+            "AXStaticText",
+            "AXCell",
+            "AXRow",
+            "AXOutline",
+            "AXScrollArea",
+            "AXWindow",
+        ]);
+        assert_eq!(
+            resolve_row_and_container(&roles),
+            RowResolution::Resolved {
+                row_idx: 2,
+                container_idx: 3,
+            }
+        );
+    }
+
+    #[test]
+    fn table_instead_of_outline_also_resolves() {
+        // NSTableView-backed sidebars report `AXTable`.
+        let roles = chain(&["AXCell", "AXRow", "AXTable", "AXScrollArea", "AXWindow"]);
+        assert_eq!(
+            resolve_row_and_container(&roles),
+            RowResolution::Resolved {
+                row_idx: 1,
+                container_idx: 2,
+            }
+        );
+    }
+
+    #[test]
+    fn non_row_descendant_chain_reports_no_row() {
+        // uid pointed at a bare button — no row in any ancestor.
+        let roles = chain(&["AXButton", "AXGroup", "AXWindow", "AXApplication"]);
+        assert_eq!(
+            resolve_row_and_container(&roles),
+            RowResolution::NoRow { depth_walked: 4 }
+        );
+    }
+
+    #[test]
+    fn row_without_outline_container_reports_no_container() {
+        // Pathological: row nested in a group that is not outline/table.
+        let roles = chain(&["AXCell", "AXRow", "AXGroup", "AXWindow", "AXApplication"]);
+        assert_eq!(
+            resolve_row_and_container(&roles),
+            RowResolution::NoContainer {
+                row_idx: 1,
+                depth_walked: 5,
+            }
+        );
+    }
+
+    #[test]
+    fn unreadable_ancestor_roles_do_not_abort_walk() {
+        // An unreadable `AXRole` on an intermediate element must not block
+        // the walk — we keep going until we find the row or run out of
+        // ancestors.
+        let roles = vec![
+            some("AXStaticText"),
+            None, // unreadable group
+            some("AXRow"),
+            None, // unreadable scroll area
+            some("AXOutline"),
+            some("AXWindow"),
+        ];
+        assert_eq!(
+            resolve_row_and_container(&roles),
+            RowResolution::Resolved {
+                row_idx: 2,
+                container_idx: 4,
+            }
+        );
+    }
+
+    #[test]
+    fn empty_chain_reports_no_row() {
+        let roles: Vec<Option<&str>> = Vec::new();
+        assert_eq!(
+            resolve_row_and_container(&roles),
+            RowResolution::NoRow { depth_walked: 0 }
+        );
+    }
+
+    #[test]
+    fn row_with_no_further_ancestors_reports_no_container() {
+        // Row at the very top of the walked chain — no outline above.
+        let roles = chain(&["AXRow"]);
+        assert_eq!(
+            resolve_row_and_container(&roles),
+            RowResolution::NoContainer {
+                row_idx: 0,
+                depth_walked: 1,
+            }
+        );
+    }
+}

--- a/src/tools/ax_row_target.rs
+++ b/src/tools/ax_row_target.rs
@@ -17,9 +17,6 @@
 //!   walk limit is an outline or table. Unusual — typically means the host
 //!   app nests rows inside a non-standard container.
 //!
-//! Both failures carry the walk depth we reached so handlers can include it
-//! in their error envelope.
-//!
 //! # Why a pure function
 //!
 //! The production walk calls into `AXParent` / `AXRole` FFI which requires
@@ -48,12 +45,9 @@ pub(crate) enum RowResolution {
         row_idx: usize,
         container_idx: usize,
     },
-    NoRow {
-        depth_walked: usize,
-    },
+    NoRow,
     NoContainer {
         row_idx: usize,
-        depth_walked: usize,
     },
 }
 
@@ -64,31 +58,23 @@ pub(crate) enum RowResolution {
 /// unreadable — common near the app root, and not fatal unless we run out
 /// of ancestors before finding a row or container.
 pub(crate) fn resolve_row_and_container(ancestor_roles: &[Option<&str>]) -> RowResolution {
-    let depth_walked = ancestor_roles.len();
-
-    // Phase 1: find the row (inclusive of the starting element).
     let Some(row_idx) = ancestor_roles
         .iter()
         .position(|r| matches!(r, Some(role) if *role == ROW_ROLE))
     else {
-        return RowResolution::NoRow { depth_walked };
+        return RowResolution::NoRow;
     };
 
-    // Phase 2: find the outline/table container above the row (exclusive).
     let Some(offset) = ancestor_roles[row_idx + 1..]
         .iter()
         .position(|r| matches!(r, Some(role) if *role == OUTLINE_ROLE || *role == TABLE_ROLE))
     else {
-        return RowResolution::NoContainer {
-            row_idx,
-            depth_walked,
-        };
+        return RowResolution::NoContainer { row_idx };
     };
-    let container_idx = row_idx + 1 + offset;
 
     RowResolution::Resolved {
         row_idx,
-        container_idx,
+        container_idx: row_idx + 1 + offset,
     }
 }
 
@@ -168,10 +154,7 @@ mod tests {
     fn non_row_descendant_chain_reports_no_row() {
         // uid pointed at a bare button — no row in any ancestor.
         let roles = chain(&["AXButton", "AXGroup", "AXWindow", "AXApplication"]);
-        assert_eq!(
-            resolve_row_and_container(&roles),
-            RowResolution::NoRow { depth_walked: 4 }
-        );
+        assert_eq!(resolve_row_and_container(&roles), RowResolution::NoRow);
     }
 
     #[test]
@@ -180,10 +163,7 @@ mod tests {
         let roles = chain(&["AXCell", "AXRow", "AXGroup", "AXWindow", "AXApplication"]);
         assert_eq!(
             resolve_row_and_container(&roles),
-            RowResolution::NoContainer {
-                row_idx: 1,
-                depth_walked: 5,
-            }
+            RowResolution::NoContainer { row_idx: 1 }
         );
     }
 
@@ -212,10 +192,7 @@ mod tests {
     #[test]
     fn empty_chain_reports_no_row() {
         let roles: Vec<Option<&str>> = Vec::new();
-        assert_eq!(
-            resolve_row_and_container(&roles),
-            RowResolution::NoRow { depth_walked: 0 }
-        );
+        assert_eq!(resolve_row_and_container(&roles), RowResolution::NoRow);
     }
 
     #[test]
@@ -224,10 +201,7 @@ mod tests {
         let roles = chain(&["AXRow"]);
         assert_eq!(
             resolve_row_and_container(&roles),
-            RowResolution::NoContainer {
-                row_idx: 0,
-                depth_walked: 1,
-            }
+            RowResolution::NoContainer { row_idx: 0 }
         );
     }
 }

--- a/src/tools/ax_row_target.rs
+++ b/src/tools/ax_row_target.rs
@@ -75,9 +75,10 @@ pub(crate) fn resolve_row_and_container(ancestor_roles: &[Option<&str>]) -> RowR
     };
 
     // Phase 2: find the outline/table container above the row (exclusive).
-    let Some(offset) = ancestor_roles[row_idx + 1..].iter().position(
-        |r| matches!(r, Some(role) if *role == OUTLINE_ROLE || *role == TABLE_ROLE),
-    ) else {
+    let Some(offset) = ancestor_roles[row_idx + 1..]
+        .iter()
+        .position(|r| matches!(r, Some(role) if *role == OUTLINE_ROLE || *role == TABLE_ROLE))
+    else {
         return RowResolution::NoContainer {
             row_idx,
             depth_walked,

--- a/src/tools/ax_select.rs
+++ b/src/tools/ax_select.rs
@@ -51,10 +51,7 @@ pub async fn ax_select(params: AxSelectParams, session: Arc<AxSession>) -> CallT
             // pure decision logic in `resolve_row_and_container` then tells
             // us which ancestors are the row and the container.
             let chain = ancestor_role_chain(ax_ref);
-            let role_strs: Vec<Option<&str>> = chain
-                .iter()
-                .map(|(_, r)| r.as_deref())
-                .collect();
+            let role_strs: Vec<Option<&str>> = chain.iter().map(|(_, r)| r.as_deref()).collect();
 
             let (row_idx, container_idx) = match resolve_row_and_container(&role_strs) {
                 RowResolution::Resolved {
@@ -73,8 +70,7 @@ pub async fn ax_select(params: AxSelectParams, session: Arc<AxSession>) -> CallT
                     // Row was found but no outline/table above it — use
                     // the row's bbox as fallback so coord-based retry at
                     // least targets the visible row.
-                    let row_bbox =
-                        unsafe { element_bbox(chain[row_idx].0.as_raw()) }.or(pre_bbox);
+                    let row_bbox = unsafe { element_bbox(chain[row_idx].0.as_raw()) }.or(pre_bbox);
                     return ax_response::error(
                         "no_outline_container",
                         "row is not nested inside an AXOutline or AXTable; \

--- a/src/tools/ax_select.rs
+++ b/src/tools/ax_select.rs
@@ -42,14 +42,10 @@ pub async fn ax_select(params: AxSelectParams, session: Arc<AxSession>) -> CallT
     // both execute under the held lock.
     let outcome = session
         .dispatch(&params.uid, |ax_ref: &AXRef| {
-            // Capture pre-dispatch bbox against the uid-targeted element
-            // so the error envelope's fallback still lands on the visible
-            // row even when the walk cannot resolve a container.
+            // Capture pre-dispatch bbox so error envelopes have a fallback
+            // centre even when the walk cannot resolve a container.
             let pre_bbox = unsafe { element_bbox(ax_ref.as_raw()) };
 
-            // Build leaf-to-root `(AXRef, Option<role>)` chain once. The
-            // pure decision logic in `resolve_row_and_container` then tells
-            // us which ancestors are the row and the container.
             let chain = ancestor_role_chain(ax_ref);
             let role_strs: Vec<Option<&str>> = chain.iter().map(|(_, r)| r.as_deref()).collect();
 
@@ -58,7 +54,7 @@ pub async fn ax_select(params: AxSelectParams, session: Arc<AxSession>) -> CallT
                     row_idx,
                     container_idx,
                 } => (row_idx, container_idx),
-                RowResolution::NoRow { .. } => {
+                RowResolution::NoRow => {
                     return ax_response::error(
                         "no_row_ancestor",
                         "uid does not resolve to an element inside an AXRow; \
@@ -66,10 +62,7 @@ pub async fn ax_select(params: AxSelectParams, session: Arc<AxSession>) -> CallT
                         pre_bbox,
                     );
                 }
-                RowResolution::NoContainer { row_idx, .. } => {
-                    // Row was found but no outline/table above it — use
-                    // the row's bbox as fallback so coord-based retry at
-                    // least targets the visible row.
+                RowResolution::NoContainer { row_idx } => {
                     let row_bbox = unsafe { element_bbox(chain[row_idx].0.as_raw()) }.or(pre_bbox);
                     return ax_response::error(
                         "no_outline_container",
@@ -84,11 +77,8 @@ pub async fn ax_select(params: AxSelectParams, session: Arc<AxSession>) -> CallT
             let container = &chain[container_idx].0;
             let row_bbox = unsafe { element_bbox(row.as_raw()) }.or(pre_bbox);
 
-            // Phase 3: write `AXSelectedRows = [row]` on the container.
             match select_rows_attribute(container, &[row]) {
                 Ok(()) => {
-                    // On success, return the row's post-dispatch bbox as
-                    // telemetry — same pattern as ax_click / ax_set_value.
                     let post_bbox = unsafe { element_bbox(row.as_raw()) }.or(row_bbox);
                     ax_response::success(DISPATCHED_VIA, post_bbox)
                 }

--- a/src/tools/ax_select.rs
+++ b/src/tools/ax_select.rs
@@ -1,0 +1,127 @@
+//! `ax_select` tool — write `AXSelectedRows` on the outline/table that
+//! encloses the uid-targeted element. This is the row-selection dispatch
+//! primitive for `NSOutlineView` / `NSTableView` sidebars, where
+//! `AXPress` is not a supported action and coordinate-based clicks would
+//! steal focus.
+//!
+//! Accepts a uid that points at the row itself, a cell within the row, or
+//! any descendant of the row. The handler walks up the `AXParent` chain
+//! to find the enclosing `AXRow` and then the enclosing `AXOutline` or
+//! `AXTable`, then writes `AXSelectedRows = [row]` on that container.
+//!
+//! The row-resolution walk and the attribute write both execute inside
+//! the `AxSession::dispatch` closure so the session's read lock is held
+//! across the whole operation — a concurrent `take_ax_snapshot` cannot
+//! publish a fresh generation mid-select.
+
+use crate::macos::ax::{
+    ancestor_role_chain, element_bbox, select_rows_attribute, AXDispatchError, AXRef,
+};
+use crate::tools::ax_response;
+use crate::tools::ax_row_target::{resolve_row_and_container, RowResolution};
+use crate::tools::ax_session::{AxSession, LookupError};
+use rmcp::model::CallToolResult;
+use serde::Deserialize;
+use std::sync::Arc;
+
+const DISPATCHED_VIA: &str = "AXSelectedRows";
+
+#[derive(Deserialize)]
+pub struct AxSelectParams {
+    pub uid: String,
+}
+
+pub async fn ax_select(params: AxSelectParams, session: Arc<AxSession>) -> CallToolResult {
+    if let Some(err) = crate::tools::input::check_permission() {
+        return err;
+    }
+
+    // `dispatch` holds the session's read lock across the closure so a
+    // concurrent `take_ax_snapshot` cannot publish a fresh generation
+    // mid-select. The walk to the enclosing row + the attribute write
+    // both execute under the held lock.
+    let outcome = session
+        .dispatch(&params.uid, |ax_ref: &AXRef| {
+            // Capture pre-dispatch bbox against the uid-targeted element
+            // so the error envelope's fallback still lands on the visible
+            // row even when the walk cannot resolve a container.
+            let pre_bbox = unsafe { element_bbox(ax_ref.as_raw()) };
+
+            // Build leaf-to-root `(AXRef, Option<role>)` chain once. The
+            // pure decision logic in `resolve_row_and_container` then tells
+            // us which ancestors are the row and the container.
+            let chain = ancestor_role_chain(ax_ref);
+            let role_strs: Vec<Option<&str>> = chain
+                .iter()
+                .map(|(_, r)| r.as_deref())
+                .collect();
+
+            let (row_idx, container_idx) = match resolve_row_and_container(&role_strs) {
+                RowResolution::Resolved {
+                    row_idx,
+                    container_idx,
+                } => (row_idx, container_idx),
+                RowResolution::NoRow { .. } => {
+                    return ax_response::error(
+                        "no_row_ancestor",
+                        "uid does not resolve to an element inside an AXRow; \
+                         ax_select only applies to NSOutlineView / NSTableView rows",
+                        pre_bbox,
+                    );
+                }
+                RowResolution::NoContainer { row_idx, .. } => {
+                    // Row was found but no outline/table above it — use
+                    // the row's bbox as fallback so coord-based retry at
+                    // least targets the visible row.
+                    let row_bbox =
+                        unsafe { element_bbox(chain[row_idx].0.as_raw()) }.or(pre_bbox);
+                    return ax_response::error(
+                        "no_outline_container",
+                        "row is not nested inside an AXOutline or AXTable; \
+                         nothing to write AXSelectedRows to",
+                        row_bbox,
+                    );
+                }
+            };
+
+            let row = &chain[row_idx].0;
+            let container = &chain[container_idx].0;
+            let row_bbox = unsafe { element_bbox(row.as_raw()) }.or(pre_bbox);
+
+            // Phase 3: write `AXSelectedRows = [row]` on the container.
+            match select_rows_attribute(container, &[row]) {
+                Ok(()) => {
+                    // On success, return the row's post-dispatch bbox as
+                    // telemetry — same pattern as ax_click / ax_set_value.
+                    let post_bbox = unsafe { element_bbox(row.as_raw()) }.or(row_bbox);
+                    ax_response::success(DISPATCHED_VIA, post_bbox)
+                }
+                Err(AXDispatchError::NotDispatchable) => ax_response::error(
+                    "not_dispatchable",
+                    "container does not expose a writable AXSelectedRows attribute",
+                    row_bbox,
+                ),
+                Err(AXDispatchError::AxError(code)) => ax_response::error(
+                    "ax_error",
+                    &format!(
+                        "AXUIElementSetAttributeValue(AXSelectedRows) failed with AX error {}",
+                        code
+                    ),
+                    row_bbox,
+                ),
+            }
+        })
+        .await;
+
+    match outcome {
+        Ok(result) => result,
+        Err(LookupError::SnapshotExpired { reason }) => {
+            ax_response::error("snapshot_expired", &reason, None)
+        }
+        Err(LookupError::UidNotFound) => ax_response::error(
+            "uid_not_found",
+            &format!("uid {} is not present in the current snapshot", params.uid),
+            None,
+        ),
+    }
+}

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -4,6 +4,10 @@ pub mod ax_click;
 #[cfg(target_os = "macos")]
 pub mod ax_response;
 #[cfg(target_os = "macos")]
+pub mod ax_row_target;
+#[cfg(target_os = "macos")]
+pub mod ax_select;
+#[cfg(target_os = "macos")]
 pub mod ax_session;
 #[cfg(target_os = "macos")]
 pub mod ax_set_value;

--- a/tests/ax_dispatch_tests.rs
+++ b/tests/ax_dispatch_tests.rs
@@ -419,11 +419,10 @@ async fn ax_set_value_preserves_focus_writing_textedit_while_terminal_is_front()
 
 /// Open a System Settings pane in the background (no focus steal) so the
 /// test runs deterministically without cursor/focus contention.
+///
+/// Does not block — callers poll via `snapshot_with_sidebar_rows` for the
+/// pane to reach a snapshot-worthy state.
 fn open_system_settings_pane(pane_id: &str) {
-    // `open -g` launches in background; `x-apple.systempreferences:<pane>`
-    // is the documented URL scheme for System Settings panes. We use
-    // `com.apple.preference.security` because Privacy & Security is a
-    // commonly-present pane across macOS versions.
     let url = format!("x-apple.systempreferences:{}", pane_id);
     let status = std::process::Command::new("open")
         .args(["-g", &url])
@@ -435,71 +434,34 @@ fn open_system_settings_pane(pane_id: &str) {
         url,
         status
     );
-    // Give Settings a moment to reach the snapshot-worthy state. The
-    // AX tree is not populated instantly after pane switch.
-    std::thread::sleep(std::time::Duration::from_millis(1500));
 }
 
-/// Find a row line in a snapshot whose subtree contains a cell with the
-/// given text. Returns `(uid, selected)` for the row or `None` when no
-/// such row exists. Heuristic: scan for lines with role `row ` and look at
-/// the immediately following lines (greater indent) for a cell whose name
-/// or value equals `text`.
-fn find_sidebar_row(snapshot: &str, text: &str) -> Option<(String, bool)> {
+#[derive(Clone, Debug)]
+struct SidebarRow {
+    uid: String,
+    selected: bool,
+    /// First labeled descendant inside the row — usually the cell's text.
+    label: String,
+}
+
+/// Collect all rows from a snapshot along with their selected state and the
+/// first labeled descendant (row cells typically carry the visible text as a
+/// quoted string like `"Privacy & Security"`).
+fn extract_sidebar_rows(snapshot: &str) -> Vec<SidebarRow> {
     let lines: Vec<&str> = snapshot.lines().collect();
+    let mut rows = Vec::new();
     for (i, line) in lines.iter().enumerate() {
         if !(line.contains(" row ") || line.contains(" row\t")) {
             continue;
         }
-        // Parse uid and selected state from this row line.
-        let uid_token = line.split_whitespace().next()?;
-        let uid = uid_token.strip_prefix("uid=")?.to_string();
-        let selected = line.contains("selected");
-        // Row indent — children must be strictly deeper.
-        let row_indent = line.len() - line.trim_start().len();
-        // Scan descendants until indent returns to <= row_indent.
-        for follow in lines.iter().skip(i + 1) {
-            let follow_indent = follow.len() - follow.trim_start().len();
-            if follow_indent <= row_indent {
-                break;
-            }
-            if follow.contains(&format!("\"{}\"", text)) {
-                return Some((uid, selected));
-            }
-        }
-    }
-    None
-}
-
-/// Smoke test: open System Settings' Privacy & Security pane, pick any
-/// sidebar row whose text differs from the currently-selected one,
-/// dispatch `ax_select` against it, and assert the selection moved. The
-/// test is tolerant of locale and version drift — it does not require a
-/// specific row to be present, only that at least two rows exist and we
-/// can flip between them.
-#[tokio::test]
-#[ignore]
-async fn ax_select_moves_sidebar_selection_in_system_settings() {
-    open_system_settings_pane("com.apple.preference.security");
-
-    let session = new_session();
-    let snap_text = snapshot(&session, Some("System Settings")).await;
-
-    // Collect all sidebar rows and their selected state.
-    let mut rows: Vec<(String, bool, String)> = Vec::new();
-    let lines: Vec<&str> = snap_text.lines().collect();
-    for (i, line) in lines.iter().enumerate() {
-        if !(line.contains(" row ") || line.contains(" row\t")) {
-            continue;
-        }
-        let Some(uid_token) = line.split_whitespace().next() else {
-            continue;
-        };
-        let Some(uid) = uid_token.strip_prefix("uid=") else {
+        let Some(uid) = line
+            .split_whitespace()
+            .next()
+            .and_then(|t| t.strip_prefix("uid="))
+        else {
             continue;
         };
         let selected = line.contains("selected");
-        // Extract any descendant label as a readable identifier for this row.
         let row_indent = line.len() - line.trim_start().len();
         let mut label = String::new();
         for follow in lines.iter().skip(i + 1) {
@@ -517,27 +479,63 @@ async fn ax_select_moves_sidebar_selection_in_system_settings() {
                 }
             }
         }
-        rows.push((uid.to_string(), selected, label));
+        rows.push(SidebarRow {
+            uid: uid.to_string(),
+            selected,
+            label,
+        });
     }
-    assert!(
-        rows.len() >= 2,
-        "System Settings sidebar should expose at least two rows; got {:?}",
-        rows
-    );
+    rows
+}
 
-    let previously_selected = rows.iter().find(|(_, sel, _)| *sel);
-    // Pick a target row: any row that is NOT the currently-selected one.
+/// Poll `snapshot` until the target app's AX tree exposes at least `min_rows`
+/// rows or the deadline expires. Returns the snapshot text on success.
+async fn snapshot_with_sidebar_rows(
+    session: &Arc<AxSession>,
+    app_name: &str,
+    min_rows: usize,
+) -> String {
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+    loop {
+        let text = snapshot(session, Some(app_name)).await;
+        if extract_sidebar_rows(&text).len() >= min_rows {
+            return text;
+        }
+        if std::time::Instant::now() >= deadline {
+            panic!(
+                "{} did not expose {} sidebar rows within 5s; last snapshot:\n{}",
+                app_name, min_rows, text
+            );
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(150)).await;
+    }
+}
+
+/// Smoke test: open System Settings' Privacy & Security pane, pick any
+/// sidebar row whose text differs from the currently-selected one,
+/// dispatch `ax_select` against it, and assert the selection moved. The
+/// test is tolerant of locale and version drift — it does not require a
+/// specific row to be present, only that at least two rows exist and we
+/// can flip between them.
+#[tokio::test]
+#[ignore]
+async fn ax_select_moves_sidebar_selection_in_system_settings() {
+    open_system_settings_pane("com.apple.preference.security");
+
+    let session = new_session();
+    let snap_text = snapshot_with_sidebar_rows(&session, "System Settings", 2).await;
+    let rows = extract_sidebar_rows(&snap_text);
+
+    let previously_selected = rows.iter().find(|r| r.selected).cloned();
     let target = rows
         .iter()
-        .find(|(_, sel, _)| !*sel)
-        .expect("at least one sidebar row should be non-selected to target");
-    let target_uid = target.0.clone();
-    let target_label = target.2.clone();
+        .find(|r| !r.selected)
+        .expect("at least one sidebar row should be non-selected to target")
+        .clone();
 
-    // Dispatch the selection.
     let result = ax_select(
         AxSelectParams {
-            uid: target_uid.clone(),
+            uid: target.uid.clone(),
         },
         session.clone(),
     )
@@ -550,31 +548,34 @@ async fn ax_select_moves_sidebar_selection_in_system_settings() {
     );
     assert_eq!(body["dispatched_via"], "AXSelectedRows");
 
-    // Re-snapshot and verify the selection moved. The new snapshot lives
-    // in a fresh session so the uids don't overlap, and we match rows by
-    // label rather than uid.
+    // Re-snapshot in a fresh session (uids don't overlap); match rows by label.
     let verify_session = new_session();
     let snap2_text = snapshot(&verify_session, Some("System Settings")).await;
+    let rows2 = extract_sidebar_rows(&snap2_text);
 
-    // The target row must now be selected.
-    let (_new_uid, now_selected) =
-        find_sidebar_row(&snap2_text, &target_label).unwrap_or_else(|| {
-            panic!("target row (label={target_label:?}) missing from post-dispatch snapshot")
-        });
+    let now_selected = rows2
+        .iter()
+        .find(|r| r.label == target.label)
+        .unwrap_or_else(|| {
+            panic!(
+                "target row (label={:?}) missing from post-dispatch snapshot",
+                target.label
+            )
+        })
+        .selected;
     assert!(
         now_selected,
         "target row (label={:?}) should be selected after ax_select",
-        target_label
+        target.label
     );
 
-    // The previously-selected row (if any) must no longer be selected.
-    if let Some((_prev_uid, _prev_sel, prev_label)) = previously_selected {
-        if prev_label != &target_label {
-            if let Some((_, still_selected)) = find_sidebar_row(&snap2_text, prev_label) {
+    if let Some(prev) = previously_selected {
+        if prev.label != target.label {
+            if let Some(still) = rows2.iter().find(|r| r.label == prev.label) {
                 assert!(
-                    !still_selected,
+                    !still.selected,
                     "previously-selected row (label={:?}) should no longer be selected",
-                    prev_label
+                    prev.label
                 );
             }
         }

--- a/tests/ax_dispatch_tests.rs
+++ b/tests/ax_dispatch_tests.rs
@@ -30,6 +30,7 @@
 
 use native_devtools_mcp::macos::ax::collect_ax_tree_indexed;
 use native_devtools_mcp::tools::ax_click::{ax_click, AxClickParams};
+use native_devtools_mcp::tools::ax_select::{ax_select, AxSelectParams};
 use native_devtools_mcp::tools::ax_session::AxSession;
 use native_devtools_mcp::tools::ax_set_value::{ax_set_value, AxSetValueParams};
 use native_devtools_mcp::tools::ax_snapshot::format_snapshot;
@@ -411,5 +412,194 @@ async fn ax_set_value_preserves_focus_writing_textedit_while_terminal_is_front()
     assert!(
         snap2_text.contains("value=\"hello\""),
         "TextEdit should reflect the written value"
+    );
+}
+
+// === ax_select — sidebar row selection in System Settings ===
+
+/// Open a System Settings pane in the background (no focus steal) so the
+/// test runs deterministically without cursor/focus contention.
+fn open_system_settings_pane(pane_id: &str) {
+    // `open -g` launches in background; `x-apple.systempreferences:<pane>`
+    // is the documented URL scheme for System Settings panes. We use
+    // `com.apple.preference.security` because Privacy & Security is a
+    // commonly-present pane across macOS versions.
+    let url = format!("x-apple.systempreferences:{}", pane_id);
+    let status = std::process::Command::new("open")
+        .args(["-g", &url])
+        .status()
+        .expect("`open` should be invocable");
+    assert!(
+        status.success(),
+        "`open -g {}` should succeed; got {:?}",
+        url,
+        status
+    );
+    // Give Settings a moment to reach the snapshot-worthy state. The
+    // AX tree is not populated instantly after pane switch.
+    std::thread::sleep(std::time::Duration::from_millis(1500));
+}
+
+/// Find a row line in a snapshot whose subtree contains a cell with the
+/// given text. Returns `(uid, selected)` for the row or `None` when no
+/// such row exists. Heuristic: scan for lines with role `row ` and look at
+/// the immediately following lines (greater indent) for a cell whose name
+/// or value equals `text`.
+fn find_sidebar_row(snapshot: &str, text: &str) -> Option<(String, bool)> {
+    let lines: Vec<&str> = snapshot.lines().collect();
+    for (i, line) in lines.iter().enumerate() {
+        if !(line.contains(" row ") || line.contains(" row\t")) {
+            continue;
+        }
+        // Parse uid and selected state from this row line.
+        let uid_token = line.split_whitespace().next()?;
+        let uid = uid_token.strip_prefix("uid=")?.to_string();
+        let selected = line.contains("selected");
+        // Row indent — children must be strictly deeper.
+        let row_indent = line.len() - line.trim_start().len();
+        // Scan descendants until indent returns to <= row_indent.
+        for follow in lines.iter().skip(i + 1) {
+            let follow_indent = follow.len() - follow.trim_start().len();
+            if follow_indent <= row_indent {
+                break;
+            }
+            if follow.contains(&format!("\"{}\"", text)) {
+                return Some((uid, selected));
+            }
+        }
+    }
+    None
+}
+
+/// Smoke test: open System Settings' Privacy & Security pane, pick any
+/// sidebar row whose text differs from the currently-selected one,
+/// dispatch `ax_select` against it, and assert the selection moved. The
+/// test is tolerant of locale and version drift — it does not require a
+/// specific row to be present, only that at least two rows exist and we
+/// can flip between them.
+#[tokio::test]
+#[ignore]
+async fn ax_select_moves_sidebar_selection_in_system_settings() {
+    open_system_settings_pane("com.apple.preference.security");
+
+    let session = new_session();
+    let snap_text = snapshot(&session, Some("System Settings")).await;
+
+    // Collect all sidebar rows and their selected state.
+    let mut rows: Vec<(String, bool, String)> = Vec::new();
+    let lines: Vec<&str> = snap_text.lines().collect();
+    for (i, line) in lines.iter().enumerate() {
+        if !(line.contains(" row ") || line.contains(" row\t")) {
+            continue;
+        }
+        let Some(uid_token) = line.split_whitespace().next() else {
+            continue;
+        };
+        let Some(uid) = uid_token.strip_prefix("uid=") else {
+            continue;
+        };
+        let selected = line.contains("selected");
+        // Extract any descendant label as a readable identifier for this row.
+        let row_indent = line.len() - line.trim_start().len();
+        let mut label = String::new();
+        for follow in lines.iter().skip(i + 1) {
+            let follow_indent = follow.len() - follow.trim_start().len();
+            if follow_indent <= row_indent {
+                break;
+            }
+            if let Some(start) = follow.find('"') {
+                let rest = &follow[start + 1..];
+                if let Some(end) = rest.find('"') {
+                    if end > 0 {
+                        label = rest[..end].to_string();
+                        break;
+                    }
+                }
+            }
+        }
+        rows.push((uid.to_string(), selected, label));
+    }
+    assert!(
+        rows.len() >= 2,
+        "System Settings sidebar should expose at least two rows; got {:?}",
+        rows
+    );
+
+    let previously_selected = rows.iter().find(|(_, sel, _)| *sel);
+    // Pick a target row: any row that is NOT the currently-selected one.
+    let target = rows
+        .iter()
+        .find(|(_, sel, _)| !*sel)
+        .expect("at least one sidebar row should be non-selected to target");
+    let target_uid = target.0.clone();
+    let target_label = target.2.clone();
+
+    // Dispatch the selection.
+    let result = ax_select(
+        AxSelectParams {
+            uid: target_uid.clone(),
+        },
+        session.clone(),
+    )
+    .await;
+    let body = parse_json(&extract_text(&result));
+    assert_eq!(
+        body["ok"], true,
+        "ax_select should succeed on a live sidebar row; body={}",
+        body
+    );
+    assert_eq!(body["dispatched_via"], "AXSelectedRows");
+
+    // Re-snapshot and verify the selection moved. The new snapshot lives
+    // in a fresh session so the uids don't overlap, and we match rows by
+    // label rather than uid.
+    let verify_session = new_session();
+    let snap2_text = snapshot(&verify_session, Some("System Settings")).await;
+
+    // The target row must now be selected.
+    let (_new_uid, now_selected) =
+        find_sidebar_row(&snap2_text, &target_label).unwrap_or_else(|| {
+            panic!("target row (label={target_label:?}) missing from post-dispatch snapshot")
+        });
+    assert!(
+        now_selected,
+        "target row (label={:?}) should be selected after ax_select",
+        target_label
+    );
+
+    // The previously-selected row (if any) must no longer be selected.
+    if let Some((_prev_uid, _prev_sel, prev_label)) = previously_selected {
+        if prev_label != &target_label {
+            if let Some((_, still_selected)) = find_sidebar_row(&snap2_text, prev_label) {
+                assert!(
+                    !still_selected,
+                    "previously-selected row (label={:?}) should no longer be selected",
+                    prev_label
+                );
+            }
+        }
+    }
+}
+
+/// Dispatching `ax_select` at a uid that has no `AXRow` ancestor must
+/// return the `no_row_ancestor` error envelope with the fallback bbox set
+/// to the starting element's centre — not panic, not succeed.
+#[tokio::test]
+#[ignore]
+async fn ax_select_on_non_row_element_returns_no_row_ancestor() {
+    // Calculator has no AXRow anywhere in its tree, so every uid is a
+    // negative case.
+    let session = new_session();
+    let snap_text = snapshot(&session, Some("Calculator")).await;
+    let five_uid = extract_uid_for_named_button(&snap_text, "5");
+
+    let result = ax_select(AxSelectParams { uid: five_uid }, session.clone()).await;
+    assert_eq!(result.is_error, Some(true));
+    let body = parse_json(&extract_text(&result));
+    assert_eq!(body["error"]["code"], "no_row_ancestor");
+    // Fallback centre should be populated from the button's bbox.
+    assert!(
+        body["error"]["fallback"].is_object(),
+        "fallback should be populated when the starting element has a bbox"
     );
 }

--- a/tests/tool_gating_tests.rs
+++ b/tests/tool_gating_tests.rs
@@ -784,7 +784,7 @@ mod ax_dispatch_tool_gating {
     use super::*;
 
     #[test]
-    fn ax_click_and_ax_set_value_are_visible_on_macos() {
+    fn ax_dispatch_triad_is_visible_on_macos() {
         let tools = MacOSDevToolsServer::get_tools(false, false, false, false, false);
         let names: Vec<String> = tools.iter().map(|t| t.name.to_string()).collect();
         assert!(names.contains(&"ax_click".to_string()));
@@ -840,7 +840,7 @@ mod ax_dispatch_tool_gating {
     }
 
     #[test]
-    fn instructions_mention_ax_click_and_ax_set_value() {
+    fn instructions_mention_ax_dispatch_triad() {
         let server = MacOSDevToolsServer::new();
         let info = server.get_info();
         let instr = info.instructions.expect("instructions should be set");
@@ -898,7 +898,7 @@ mod ax_dispatch_tool_gating_non_macos {
     use super::*;
 
     #[test]
-    fn ax_click_and_ax_set_value_are_absent_off_macos() {
+    fn ax_dispatch_triad_is_absent_off_macos() {
         let tools = MacOSDevToolsServer::get_tools(true, true, true, true, true);
         let names: Vec<String> = tools.iter().map(|t| t.name.to_string()).collect();
         assert!(!names.contains(&"ax_click".to_string()));

--- a/tests/tool_gating_tests.rs
+++ b/tests/tool_gating_tests.rs
@@ -789,6 +789,7 @@ mod ax_dispatch_tool_gating {
         let names: Vec<String> = tools.iter().map(|t| t.name.to_string()).collect();
         assert!(names.contains(&"ax_click".to_string()));
         assert!(names.contains(&"ax_set_value".to_string()));
+        assert!(names.contains(&"ax_select".to_string()));
     }
 
     #[test]
@@ -823,6 +824,22 @@ mod ax_dispatch_tool_gating {
     }
 
     #[test]
+    fn ax_select_flagged_state_change() {
+        let tools = MacOSDevToolsServer::get_tools(false, false, false, false, false);
+        let tool = tools
+            .iter()
+            .find(|t| t.name.as_ref() == "ax_select")
+            .expect("ax_select not found");
+        let ann = tool
+            .annotations
+            .as_ref()
+            .expect("ax_select should have annotations");
+        assert_eq!(ann.read_only_hint, Some(false));
+        assert_eq!(ann.destructive_hint, Some(false));
+        assert_eq!(ann.idempotent_hint, Some(false));
+    }
+
+    #[test]
     fn instructions_mention_ax_click_and_ax_set_value() {
         let server = MacOSDevToolsServer::new();
         let info = server.get_info();
@@ -834,6 +851,10 @@ mod ax_dispatch_tool_gating {
         assert!(
             instr.contains("ax_set_value"),
             "instructions should mention ax_set_value"
+        );
+        assert!(
+            instr.contains("ax_select"),
+            "instructions should mention ax_select"
         );
         assert!(
             instr.contains("take_ax_snapshot"),
@@ -852,6 +873,7 @@ mod ax_dispatch_tool_gating {
     #[test]
     fn ax_dispatch_param_structs_accept_schema_fields() {
         use native_devtools_mcp::tools::ax_click::AxClickParams;
+        use native_devtools_mcp::tools::ax_select::AxSelectParams;
         use native_devtools_mcp::tools::ax_set_value::AxSetValueParams;
 
         let p: AxClickParams = serde_json::from_value(serde_json::json!({ "uid": "a1g1" }))
@@ -863,6 +885,10 @@ mod ax_dispatch_tool_gating {
                 .expect("ax_set_value params must accept { uid, text }");
         assert_eq!(q.uid, "a2g1");
         assert_eq!(q.text, "hello");
+
+        let s: AxSelectParams = serde_json::from_value(serde_json::json!({ "uid": "a3g1" }))
+            .expect("ax_select params must accept { uid }");
+        assert_eq!(s.uid, "a3g1");
     }
 }
 
@@ -877,6 +903,7 @@ mod ax_dispatch_tool_gating_non_macos {
         let names: Vec<String> = tools.iter().map(|t| t.name.to_string()).collect();
         assert!(!names.contains(&"ax_click".to_string()));
         assert!(!names.contains(&"ax_set_value".to_string()));
+        assert!(!names.contains(&"ax_select".to_string()));
     }
 
     #[test]
@@ -890,6 +917,10 @@ mod ax_dispatch_tool_gating_non_macos {
         );
         assert!(
             !instr.contains("ax_set_value"),
+            "Windows/Linux build must not advertise macOS-only tools in instructions"
+        );
+        assert!(
+            !instr.contains("ax_select"),
             "Windows/Linux build must not advertise macOS-only tools in instructions"
         );
     }


### PR DESCRIPTION
## Summary

New macOS-only MCP tool `ax_select` that writes `AXSelectedRows` on the enclosing outline or table of a uid-targeted element. Closes the gap where rows and cells in `NSOutlineView` / `NSTableView` refuse `AXPress` (returning `not_dispatchable` or AX error `-25205`), leaving only a focus-stealing coordinate click as the prior fallback.

Accepts a uid pointing at the row, a cell inside the row, or any descendant — walks up the `AXParent` chain to find the enclosing `AXRow` and `AXOutline`/`AXTable`.

A pure `resolve_row_and_container()` in `tools::ax_row_target` drives the row/container selection from a precomputed ancestor role chain, so every branch is unit-testable without live `AXUIElement` handles. The FFI walk (`ancestor_role_chain`) runs inside `AxSession::dispatch` so the session's read lock is held across the whole operation — a concurrent `take_ax_snapshot` cannot invalidate handles mid-select.

Stacks on top of `feat/ax-dispatch` (already merged). Four commits: feature, tests, docs, and a simplify pass after external review.

Closes #7.

## Test plan

- [x] `cargo test --lib` — 231 passed, 9 ignored, 0 failed
- [x] `cargo test --test tool_gating_tests` — 53 passed
- [x] `cargo test --test ax_dispatch_tests --no-run` — compiles clean (integration tests are `#[ignore]`-gated)
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all --check` — clean
- [x] End-to-end smoke on a live macOS host: opened System Settings in the background, dispatched `ax_select` against the "General" cell's text uid (descendant→row walk), the "Displays" row uid (row-as-start), and a menubar item uid (`no_row_ancestor` negative path). All three behaved as designed; focus never left the foreground app.
- [ ] Manual run of ignored integration tests: `cargo test --test ax_dispatch_tests -- --ignored --test-threads=1` on a host with Calculator + TextEdit + System Settings reachable.